### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,9 @@ on:
       - .github/workflows/build.yml
       - src/*
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -131,6 +134,8 @@ jobs:
           path: github-device-flow.macos.zip
 
   create_release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: [build_arm, build_armv7, build_macos, build_x86_64]
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Potential fix for [https://github.com/jakewilkins/gh-device-flow/security/code-scanning/5](https://github.com/jakewilkins/gh-device-flow/security/code-scanning/5)

Add explicit `permissions` to `.github/workflows/rust.yml`:

- At workflow root (applies to all jobs): set minimal defaults, e.g. `contents: read`.
- At `jobs.create_release`: override with required write scope for release creation and asset upload, i.e. `contents: write`.

This preserves functionality:
- Build jobs keep least privilege.
- `create_release` still can create releases and upload assets.

Change region:
- Insert root `permissions` block after `on:` triggers (before `env:` is clean/readable).
- Insert job-level `permissions` under `create_release:` before `runs-on:`.

No imports/dependencies/methods are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
